### PR TITLE
Add TestNG framework multi-module project

### DIFF
--- a/datemodule/pom.xml
+++ b/datemodule/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>testngframework-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>datemodule</artifactId>
+</project>

--- a/datemodule/src/main/java/com/example/datemodule/DateUtils.java
+++ b/datemodule/src/main/java/com/example/datemodule/DateUtils.java
@@ -1,0 +1,12 @@
+package com.example.datemodule;
+
+import java.time.LocalDate;
+
+public final class DateUtils {
+    private DateUtils() {
+    }
+
+    public static String getCurrentDate() {
+        return LocalDate.now().toString();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>testngframework-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>datemodule</module>
+        <module>testngframework</module>
+    </modules>
+</project>

--- a/testngframework/pom.xml
+++ b/testngframework/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>testngframework-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>testngframework</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>datemodule</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.aventstack</groupId>
+            <artifactId>extentreports</artifactId>
+            <version>5.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.10.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testngframework/src/main/java/com/example/framework/base/BaseTest.java
+++ b/testngframework/src/main/java/com/example/framework/base/BaseTest.java
@@ -1,0 +1,19 @@
+package com.example.framework.base;
+
+import com.example.framework.utilities.DriverFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public abstract class BaseTest {
+
+    @BeforeMethod
+    public void setUp() {
+        // Driver setup can be extended for real browsers
+        DriverFactory.setDriver(null);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        DriverFactory.unload();
+    }
+}

--- a/testngframework/src/main/java/com/example/framework/listeners/TestListener.java
+++ b/testngframework/src/main/java/com/example/framework/listeners/TestListener.java
@@ -1,0 +1,37 @@
+package com.example.framework.listeners;
+
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+public class TestListener implements ITestListener {
+    @Override
+    public void onTestStart(ITestResult result) {
+        // placeholder for onTestStart
+    }
+
+    @Override
+    public void onTestSuccess(ITestResult result) {
+        // placeholder for onTestSuccess
+    }
+
+    @Override
+    public void onTestFailure(ITestResult result) {
+        // placeholder for onTestFailure
+    }
+
+    @Override
+    public void onTestSkipped(ITestResult result) {
+        // placeholder for onTestSkipped
+    }
+
+    @Override
+    public void onStart(ITestContext context) {
+        // placeholder for onStart
+    }
+
+    @Override
+    public void onFinish(ITestContext context) {
+        // placeholder for onFinish
+    }
+}

--- a/testngframework/src/main/java/com/example/framework/reporting/ExtentManager.java
+++ b/testngframework/src/main/java/com/example/framework/reporting/ExtentManager.java
@@ -1,0 +1,20 @@
+package com.example.framework.reporting;
+
+import com.aventstack.extentreports.ExtentReports;
+import com.aventstack.extentreports.reporter.ExtentSparkReporter;
+
+public final class ExtentManager {
+    private ExtentManager() {
+    }
+
+    private static ExtentReports extent;
+
+    public static ExtentReports getExtentReports() {
+        if (extent == null) {
+            ExtentSparkReporter reporter = new ExtentSparkReporter("extent-report.html");
+            extent = new ExtentReports();
+            extent.attachReporter(reporter);
+        }
+        return extent;
+    }
+}

--- a/testngframework/src/main/java/com/example/framework/utilities/DriverFactory.java
+++ b/testngframework/src/main/java/com/example/framework/utilities/DriverFactory.java
@@ -1,0 +1,22 @@
+package com.example.framework.utilities;
+
+import org.openqa.selenium.WebDriver;
+
+public final class DriverFactory {
+    private static final ThreadLocal<WebDriver> DRIVER = new ThreadLocal<>();
+
+    private DriverFactory() {
+    }
+
+    public static void setDriver(WebDriver driver) {
+        DRIVER.set(driver);
+    }
+
+    public static WebDriver getDriver() {
+        return DRIVER.get();
+    }
+
+    public static void unload() {
+        DRIVER.remove();
+    }
+}

--- a/testngframework/src/main/java/com/example/framework/utilities/FileUtilsEx.java
+++ b/testngframework/src/main/java/com/example/framework/utilities/FileUtilsEx.java
@@ -1,0 +1,14 @@
+package com.example.framework.utilities;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class FileUtilsEx {
+    private FileUtilsEx() {
+    }
+
+    public static String readFile(String path) throws IOException {
+        return Files.readString(Path.of(path));
+    }
+}

--- a/testngframework/src/main/java/com/example/framework/utilities/KeyboardUtils.java
+++ b/testngframework/src/main/java/com/example/framework/utilities/KeyboardUtils.java
@@ -1,0 +1,10 @@
+package com.example.framework.utilities;
+
+public final class KeyboardUtils {
+    private KeyboardUtils() {
+    }
+
+    public static void pressEnter() {
+        // placeholder for keyboard action
+    }
+}

--- a/testngframework/src/test/java/com/example/tests/SampleTest.java
+++ b/testngframework/src/test/java/com/example/tests/SampleTest.java
@@ -1,0 +1,15 @@
+package com.example.tests;
+
+import com.example.datemodule.DateUtils;
+import com.example.framework.base.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SampleTest extends BaseTest {
+
+    @Test
+    public void testCurrentDateIsNotNull() {
+        String date = DateUtils.getCurrentDate();
+        Assert.assertNotNull(date);
+    }
+}

--- a/testngframework/src/test/resources/testng.xml
+++ b/testngframework/src/test/resources/testng.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<suite name="Sample Suite">
+    <test name="SampleTest">
+        <classes>
+            <class name="com.example.tests.SampleTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Summary
- add parent pom and modules for `datemodule` and `testngframework`
- implement date utility and basic test framework classes
- include sample TestNG test and configuration

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68972ad2f6ac832ba68b28d98e8cdaf4