### PR TITLE
Set TestNG dependency scope to compile

### DIFF
--- a/testngframework/pom.xml
+++ b/testngframework/pom.xml
@@ -31,7 +31,7 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>7.10.2</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- change the TestNG dependency scope from test to compile

## Testing
- `mvn clean compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68973ecc3c44832b89d94ea71b4ff3a9